### PR TITLE
fix error in eval_convert_image if both shrink and convert are false

### DIFF
--- a/src/szurubooru_toolkit/scripts/upload_media.py
+++ b/src/szurubooru_toolkit/scripts/upload_media.py
@@ -179,6 +179,7 @@ def eval_convert_image(file: bytes, file_ext: str, file_to_upload: str = None) -
     """
 
     file_size = len(file)
+    image = file
 
     try:
         if (
@@ -220,7 +221,6 @@ def eval_convert_image(file: bytes, file_ext: str, file_to_upload: str = None) -
     except OSError:
         print('')
         logger.warning(f'Could not shrink image {file_to_upload}. Keeping dimensions...')
-        image = file
 
     return image
 


### PR DESCRIPTION
i was trying the tool for my local szurubooru and noticed that when i launched import-from-booru it threw the following error

```
szuru-bot@szuru-bot:/media/sf_Sharedfolder$ import-from-booru danbooru "yue_(shemika98425261)"
[INFO] [19.08.2022, 17:42:16 UTC]: Retrieving posts from danbooru with query "yue_(shemika98425261)"...
[INFO] [19.08.2022, 17:42:17 UTC]: Found 100 posts. Start importing...
[ERROR] [19.08.2022, 17:42:26 UTC] [import-from-booru.<module>]: An error has been caught in function '<module>', process 'MainProcess' (5813), thread 'MainThread' (139832063139840):
Traceback (most recent call last):
  File "/home/szuru-bot/.local/lib/python3.10/site-packages/szurubooru_toolkit/scripts/import_from_booru.py", line 177, in main
    next(result)
StopIteration

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/szuru-bot/.local/bin/import-from-booru", line 8, in <module>
    sys.exit(main())
  File "/home/szuru-bot/.local/lib/python3.10/site-packages/szurubooru_toolkit/scripts/import_from_booru.py", line 180, in main
    import_post(booru, post, file_ext, md5)
  File "/home/szuru-bot/.local/lib/python3.10/site-packages/szurubooru_toolkit/scripts/import_from_booru.py", line 112, in import_post
    upload_media.main(file, file_ext, metadata)
  File "/home/szuru-bot/.local/lib/python3.10/site-packages/szurubooru_toolkit/scripts/upload_media.py", line 312, in main
    upload_post(file_to_upload, file_ext, metadata)
  File "/home/szuru-bot/.local/lib/python3.10/site-packages/szurubooru_toolkit/scripts/upload_media.py", line 232, in upload_post
    post.media = eval_convert_image(file, file_ext, file_to_upload)
  File "/home/szuru-bot/.local/lib/python3.10/site-packages/szurubooru_toolkit/scripts/upload_media.py", line 225, in eval_convert_image
    return image
UnboundLocalError: local variable 'image' referenced before assignment
```

upon further inspection i noticed that "eval_convert_image()" doesn't assign a value to "image" unless shrink and/or convert are set to true or if a OSError is thrown, so i tried fixing it by setting as the default value the unchanged file
i don't have that much python knowledge but the change seemed simple enough to do on my own, for the same reason i haven't tested it