### PR TITLE
Small bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 config.json
 config.toml
 .vscode
+szurubooru_toolkit.log
+temp/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -88,6 +90,7 @@ ipython_config.py
 
 # pyenv
 .python-version
+.tool-versions
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
@@ -109,6 +112,7 @@ celerybeat.pid
 # Environments
 .env
 .venv
+.envrc
 env/
 venv/
 ENV/

--- a/crontab
+++ b/crontab
@@ -1,0 +1,1 @@
+*/30 * * * * root poetry --ansi --no-interaction run auto-tagger --add-tags deepbooru "type:image -deepbooru"

--- a/src/szurubooru_toolkit/scripts/auto_tagger.py
+++ b/src/szurubooru_toolkit/scripts/auto_tagger.py
@@ -17,6 +17,7 @@ from szurubooru_toolkit.utils import scrape_sankaku
 from szurubooru_toolkit.utils import shrink_img
 from szurubooru_toolkit.utils import statistics
 
+from PIL import UnidentifiedImageError
 
 def parse_args() -> tuple:
     """Parse the input args to the script auto_tagger.py and set the variables accordingly."""
@@ -226,8 +227,11 @@ def main(post_id: str = None, file_to_upload: bytes = None) -> None:  # noqa C90
                 if not config.szurubooru['public'] or config.auto_tagger['deepbooru_enabled']:
                     image = download_media(post.content_url, post.md5)
                     # Shrink files >2MB
-                    if len(image) > 2000000:
-                        image = shrink_img(image, resize=True, convert=True)
+                    try:
+                        if len(image) > 2000000:
+                            image = shrink_img(image, resize=True, convert=True)
+                    except UnidentifiedImageError:
+                        logger.warning('Could not shrink image')
                 else:
                     image = None  # Let SauceNAO download the image from public szurubooru URL
             else:

--- a/src/szurubooru_toolkit/scripts/auto_tagger.py
+++ b/src/szurubooru_toolkit/scripts/auto_tagger.py
@@ -252,11 +252,16 @@ def main(post_id: str = None, file_to_upload: bytes = None) -> None:  # noqa C90
                 limit_reached = False
 
             if (not tags and config.auto_tagger['deepbooru_enabled']) or config.auto_tagger['deepbooru_forced']:
-                tags, post.safety = deepbooru.tag_image(
+                result = deepbooru.tag_image(
                     image,
                     config.auto_tagger['deepbooru_threshold'],
                     config.auto_tagger['deepbooru_set_tag'],
                 )
+                
+                if result is None:
+                    continue
+                
+                tags, post.safety = result
 
                 if post.relations:
                     set_tags_from_relations(post)

--- a/src/szurubooru_toolkit/szurubooru.py
+++ b/src/szurubooru_toolkit/szurubooru.py
@@ -60,7 +60,7 @@ class Szurubooru:
 
         try:
             # Ignore mp4 and webms
-            query_params = {'query': query, 'type': 'image,animation'}
+            query_params = {'query': f"type:image,animation {query}"}
             query_url = self.szuru_api_url + '/posts/?' + urllib.parse.urlencode(query_params)
             logger.debug(f'Getting post from query_url: {query_url}')
 


### PR DESCRIPTION
Please let me know if you'd like any changes to this PR!

## Assorted Fixes
- Catch errors when shrinking images (9c2f45b4628382f5fa33de624211efbded9cb818)
- Continue if deepbooru is unable to tag an image for some reason (79cc89355e054c7799d7621799ace2446e4be649)
- Add additional miscellaneous files to `.gitignore` (af26415d2f14a1ce9900c71a225ad74e76100e9e)
  - `.tool-versions` is used by asdf version manager, and `.envrc` is used by direnv
- Fix type query param not filtering only to `type:image,animation` (1c02aea0f840053d0a097652e6ab338c9e4dd7df)
  - I just added it into the query string since it seems like szurubooru wasn't picking up the query params
  
## Issues
Closes #22