### PR TITLE
Add sankaku to config sample

### DIFF
--- a/config_sample.toml
+++ b/config_sample.toml
@@ -27,6 +27,9 @@ password = "None"
 [yandere]
 user = "None"
 password = "None"
+[sankaku]
+user = "None"
+password = "None"
 [pixiv]
 user = "None"
 password = "None"


### PR DESCRIPTION
Sankaku is required in config but not present in sample.