### PR TITLE
improve docker

### DIFF
--- a/crontab
+++ b/crontab
@@ -1,1 +1,0 @@
-*/30 * * * * root poetry --ansi --no-interaction run auto-tagger --add-tags deepbooru "type:image -deepbooru"

--- a/crontab_sample
+++ b/crontab_sample
@@ -1,1 +1,1 @@
-*/30 * * * *  cd /szurubooru-toolkit && /usr/local/bin/auto-tagger "-source:*donmai* -source:*gelbooru* -source:*yande* sort:date,asc" > /proc/1/fd/1 2>&1
+*/30 * * * *  flock -n /tmp/szuru-toolkit.lock -c "cd /szurubooru-toolkit && /usr/local/bin/auto-tagger \"-source:*donmai* -source:*gelbooru* -source:*yande* sort:date,asc\" >/proc/1/fd/1 2>&1"


### PR DESCRIPTION
just a couple small improvements:
- remove `crontab` file that shouldn't have ever been there
- use `flock` which is already in the container to prevent multiple instances of szurubooru-toolkit from running at once
  - if the command is run a second time while the first is still running, the `-n` argument will make the second instance exit immediately